### PR TITLE
Publicize all fields on `AddOperation` and `Style`

### DIFF
--- a/azalea-protocol/src/packets/game/clientbound_boss_event_packet.rs
+++ b/azalea-protocol/src/packets/game/clientbound_boss_event_packet.rs
@@ -76,16 +76,16 @@ impl McBufWritable for Operation {
 
 #[derive(Clone, Debug, McBuf)]
 pub struct AddOperation {
-    name: FormattedText,
-    progress: f32,
-    style: Style,
-    properties: Properties,
+    pub name: FormattedText,
+    pub progress: f32,
+    pub style: Style,
+    pub properties: Properties,
 }
 
 #[derive(Clone, Debug, McBuf)]
 pub struct Style {
-    color: BossBarColor,
-    overlay: BossBarOverlay,
+    pub color: BossBarColor,
+    pub overlay: BossBarOverlay,
 }
 
 #[derive(McBuf, Clone, Copy, Debug)]


### PR DESCRIPTION
The struct itself was already public, I assume the fields where meant to be as well.